### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,7 @@ class ItemsController < ApplicationController
       end
     end
 
+
     def show
     end
 
@@ -37,6 +38,14 @@ class ItemsController < ApplicationController
         render :edit, status: :unprocessable_entity
       end 
     end
+
+
+    def destroy
+        @item = Item.find(params[:id])
+        @item.destroy
+        redirect_to root_path
+    end
+    
 
     def set_item
       @item = Item.find(params[:id])

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if  current_user.id == @item.user_id  %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   root to: 'items#index'
-  resources :items, only: [:new, :create, :show, :edit, :update]
+  resources :items, only: [:new, :create, :show, :edit, :update, :destroy]
   
 end


### PR DESCRIPTION
#What
最終課題アプリfurimaについて商品情削除機能の実装

#Why
furimaの作成に当たり、商品詳細ページの情報を削除させるため

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/bfe187048ae6ea5eb0f60d499b52361f